### PR TITLE
[NO-ISSUE] Switch constructor syntax for class syntax

### DIFF
--- a/js/book.js
+++ b/js/book.js
@@ -1,17 +1,50 @@
-function Book(attrs) {
-  this.title = attrs.title;
-  this.author = attrs.author;
-  this.pages = attrs.pages;
-  this.read = attrs.read;
-  this.coverColor = bookCoverColors[Math.floor(Math.random() * bookCoverColors.length)];
+class Book {
+  // Properties
+  #title;
+  #author;
+  #pages;
+  #read;
+  #coverColor;
 
-  this.info = function() {
+  constructor(attrs) {
+    this.#title = attrs.title;
+    this.#author = attrs.author;
+    this.#pages = attrs.pages;
+    this.#read = attrs.read;
+    this.#coverColor = bookCoverColors[Math.floor(Math.random() * bookCoverColors.length)];
+  }
+
+  // Getters
+  get title() {
+    return this.#title;
+  }
+
+  get author() {
+    return this.#author;
+  }
+
+  get pages() {
+    return this.#pages;
+  }
+
+  get read() {
+    return this.#read;
+  }
+  
+  get coverColor() {
+    return this.#coverColor;
+  }
+
+  // Methods
+  toggleRead() {
+    this.#read = !this.#read;
+  }
+
+  // Not used in UI
+  info() {
     readStatus = this.read ? 'read' : 'not read yet';
     
     return `${this.title} by ${this.author}, ${this.pages} pages, ${readStatus}`;
   }
-
-  this.toggleRead = () => {
-    this.read = !this.read;
-  }
+  // Not used in UI
 }


### PR DESCRIPTION
This PR...

## Changes
As a practice in using ES6 classes...
-  Refactors the Book constructor into a class based object.
Exposing fields only via getters and adding privacy to properties. Also, the only setter needed is
for the `read` status, so exposed `toggleRead` as the setter for it.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

Fixes #